### PR TITLE
Change ctrl-p to be an output mode toggle

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,14 @@
+0.2.0
+=====
+
+* Backwards incompatible: Ctrl-p has been changed to now
+  be an output mode toggle.  The output mode tells jpterm
+  what to print (if anything) when it exits.  You can now
+  no longer save and print multiple expressions.
+* You can now exit jpterm using ctrl-c in addition to
+  F5.  This fixes issues for people that were unable to
+  use F5 previously.
+
 0.1.0
 =====
 

--- a/README.rst
+++ b/README.rst
@@ -48,18 +48,39 @@ You can also pipe an input JSON document into the
 
 .. image:: https://cloud.githubusercontent.com/assets/368057/5158770/6a6afb6e-72fe-11e4-8be3-893edf21920e.gif
 
+Output
+------
+
+When the ``jpterm`` program exits (via ``F5`` or ``Ctrl-c``), ``jpterm`` may
+write content to stdout depending on the output mode.  There are three output
+modes:
+
+* result - Whatever is in the "JMESPath result" pane (the right hand side) will
+  be printed to stdout.
+* expression - Whatever is in the "JMESPath expression" pane is printed to
+  stdout.
+* nothing - Nothing is written to stdout when exiting.
+
+The default mode is "result", which means that by default, whatever is in the
+result pane will be printed to stdout when ``jpterm`` exits.  You can switch
+output modes using ``Ctrl-p``, which will cycle through the three modes above.
+You can also specify what mode to use when starting the ``jpterm`` command
+using the ``-m/--output-mode`` command line option.
+
 Keyboard Shortcuts
-__________________
+------------------
+
 ``F5 or Ctrl + c``
     | Quit the program.
 ``Ctrl + p``
-    | Save the current expression so that it is output on quit.
-    | (Multiple expressions can be saved and each is output on its own line.
+    | Output mode toggle.  Toggle between outputting the current result,
+    | expression, or nothing.  This is discussed in the "Output" section above.
 ``Ctrl + ]``
     | Clear the current expression.
 
 Mouse Clicks
-____________
+------------
+
 NOTE: These features are dependent on terminal support. (The Terminal.app
 included in Mac OS X does not support this, but `iTerm2 <http://iterm2.com/>`_
 does.)

--- a/jpterm.py
+++ b/jpterm.py
@@ -162,7 +162,8 @@ class JMESPathDisplay(object):
             self.footer.set_text("Status: output mode set to %s" % new_mode)
 
     def display_output(self):
-        if self.output_mode == 'result':
+        if self.output_mode == 'result' and \
+                self.last_result is not None:
             print(json.dumps(self.last_result, indent=2))
         elif self.output_mode == 'expression' and \
                 self.last_expression is not None:

--- a/jpterm.py
+++ b/jpterm.py
@@ -23,6 +23,11 @@ SAMPLE_JSON = {
     "e": None,
     "f": 1.1
 }
+OUTPUT_MODES = [
+    'result',
+    'expression',
+    'quiet',
+]
 
 
 class ConsoleJSONFormatter(object):
@@ -58,12 +63,14 @@ class JMESPathDisplay(object):
         ('bigtext', 'white', 'black'),
     ]
 
-    def __init__(self, input_data):
+    def __init__(self, input_data, output_mode='result'):
         self.view = None
         self.parsed_json = input_data
         self.lexer = pygments.lexers.get_lexer_by_name('json')
         self.formatter = ConsoleJSONFormatter()
-        self.saved_expressions = []
+        self.output_mode = output_mode
+        self.last_result = None
+        self.last_expression = None
 
     def _create_colorized_json(self, json_string):
         tokens = self.lexer.get_tokens(json_string)
@@ -111,6 +118,7 @@ class JMESPathDisplay(object):
                                 footer=self.footer, focus_part='header')
 
     def _on_edit(self, widget, text):
+        self.last_expression = text
         if not text:
             # If a user has hit backspace until there's no expression
             # left, we can exit early and just clear the result text
@@ -124,6 +132,7 @@ class JMESPathDisplay(object):
             pass
         else:
             if result is not None:
+                self.last_result = result
                 result_markup = self._create_colorized_json(
                     json.dumps(result, indent=2))
                 self.jmespath_result.set_text(result_markup)
@@ -147,12 +156,18 @@ class JMESPathDisplay(object):
             self.input_expr.edit_text = ''
             self.jmespath_result.set_text('')
         elif key == 'ctrl p':
-            self.saved_expressions.append(self.input_expr.edit_text)
-            self.footer.set_text("Status: expression saved")
+            new_mode = OUTPUT_MODES[
+                (OUTPUT_MODES.index(self.output_mode) + 1) % len(OUTPUT_MODES)]
+            self.output_mode = new_mode
+            self.footer.set_text("Status: output mode set to %s" % new_mode)
 
-    def display_saved_expressions(self):
-        for expression in self.saved_expressions:
-            print(expression)
+    def display_output(self):
+        if self.output_mode == 'result':
+            print(json.dumps(self.last_result, indent=2))
+        elif self.output_mode == 'expression' and \
+                self.last_expression is not None:
+            print(self.last_expression)
+        # If the output_mode is 'quiet' then we don't need to print anything.
 
 
 def _load_input_json(filename):
@@ -179,6 +194,12 @@ def main():
                         help='The initial input JSON file to use. '
                         'If this value is not provided, a sample '
                         'JSON document will be provided.')
+    parser.add_argument('-m', '--output-mode',
+                        choices=OUTPUT_MODES,
+                        default='result',
+                        help="Specify what's printed to stdout "
+                        "when jpterm exits. This can also be changed "
+                        "when jpterm is running using Ctrl-o")
     parser.add_argument('--version', action='version',
                         version='jmespath-term %s' % __version__)
 
@@ -190,12 +211,12 @@ def main():
         return 1
 
     screen = urwid.raw_display.Screen()
-    display = JMESPathDisplay(input_json)
+    display = JMESPathDisplay(input_json, args.output_mode)
     try:
         display.main(screen=screen)
     except KeyboardInterrupt:
         pass
-    display.display_saved_expressions()
+    display.display_output()
     return 0
 
 


### PR DESCRIPTION
This is one way to address #5.

I'd like to play around with this a bit more and make sure this is the behavior I'd like, but this seems like a clean way to handle either printing the expression or the result.

Demo:

![jpterm-output-demo](https://cloud.githubusercontent.com/assets/368057/7695250/6e96fa7a-fda1-11e4-8662-7c9b1e59c1e1.gif)

Note that this is a backwards incompatible change, but I haven't actually found the printing multiple expression via repeated ctrl-p behavior all the useful in practice and I think long term this is better.
