### PR TITLE
Use collections.OrderedDict to retain key order

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,15 @@
+0.2.2
+=====
+
+* Use OrderedDict to retain key order from expression
+  in output.
+
 0.2.1
 =====
 
 * Add an ``-o|--output-file`` option that allows you to
   control where the final output is written.
 * Relax pygments version constraint.
-
 
 0.2.0
 =====

--- a/jpterm.py
+++ b/jpterm.py
@@ -7,9 +7,10 @@ import argparse
 import urwid
 import jmespath
 import pygments.lexers
+import collections
 
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 
 SAMPLE_JSON = {
@@ -126,7 +127,8 @@ class JMESPathDisplay(object):
             self.jmespath_result.set_text('')
             return
         try:
-            result = jmespath.compile(text).search(self.parsed_json)
+            options = jmespath.Options(dict_cls=collections.OrderedDict)
+            result = jmespath.compile(text).search(self.parsed_json, options)
             self.footer.set_text("Status: success")
         except Exception:
             pass

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 
 requires = [
-    'jmespath>=0.4.1,<=1.0.0',
+    'jmespath>=0.8.0,<=1.0.0',
     'Pygments>=2.0,<3.0',
     'urwid==1.2.2'
 ]
@@ -15,7 +15,7 @@ requires = [
 
 setup(
     name='jmespath-terminal',
-    version='0.2.1',
+    version='0.2.2',
     description='JMESPath Terminal',
     long_description=io.open('README.rst', encoding='utf-8').read(),
     author='James Saryerwinnie',


### PR DESCRIPTION
This will honor key order from the expression when constructing the output. Requires jmespath.py 0.8.0 or newer.
