### PR TITLE
bump to newer urwid

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 requires = [
     'jmespath>=0.8.0,<=1.0.0',
     'Pygments>=2.0,<3.0',
-    'urwid==1.2.2'
+    'urwid==2.1.2'
 ]
 
 


### PR DESCRIPTION
I wasn't able to `pip install jsmespath-terminal` due to an error with urwid 1.2.2 not working on newer pythons.

Bumping the version just seems to work and 2.1.2 [still supports python 2.7](https://urwid.org/changelog.html#urwid-2-1-2)

fixes https://github.com/jmespath/jmespath.terminal/issues/19